### PR TITLE
Adiciona `filtro das exceções` 

### DIFF
--- a/src/Backend/SistemaDeEstoque.Api/Filtros/FiltroDasExceptions.cs
+++ b/src/Backend/SistemaDeEstoque.Api/Filtros/FiltroDasExceptions.cs
@@ -1,0 +1,46 @@
+namespace SistemaDeEstoque.Api.Filtros;
+
+public class FiltroDasExceptions : IExceptionFilter
+{
+    public void OnException(ExceptionContext context)
+    {
+        if (context.Exception is SistemaDeEstoqueException)
+            TratarSistemaDeEstoqueException(context);
+
+        else
+            LancarErroDesconhecido(context);
+    }
+
+    private static void TratarSistemaDeEstoqueException(ExceptionContext context)
+    {
+        if (context.Exception is ErrosDeValidacaoException)
+            TratarErrosDeValidacaoException(context);
+
+        else if (context.Exception is LoginInvalidoException)
+            TratarLoginException(context);
+
+    }
+
+    private static void TratarErrosDeValidacaoException(ExceptionContext context)
+    {
+        var erroDeValidacaoException = context.Exception as ErrosDeValidacaoException;
+
+        context.HttpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+        context.Result = new ObjectResult(new RespostaErroJson(erroDeValidacaoException.MensagemDeErro));
+    }
+
+    private static void TratarLoginException(ExceptionContext context)
+    {
+        var erroLogin = context.Exception as LoginInvalidoException;
+        context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+        context.Result = new ObjectResult(new RespostaErroJson(erroLogin.Message));
+    }
+
+    private static void LancarErroDesconhecido(ExceptionContext context)
+    {
+        context.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+        context.Result = new ObjectResult(new RespostaErroJson(ModelMensagensDeErro.ERRO_DESCONHECIDO));
+    }
+
+
+}

--- a/src/Backend/SistemaDeEstoque.Api/Program.cs
+++ b/src/Backend/SistemaDeEstoque.Api/Program.cs
@@ -39,6 +39,8 @@ builder.Services.AddSwaggerGen(option =>
 builder.Services.AdicionarInfrastructure(builder.Configuration);
 builder.Services.AdicionarApplication(builder.Configuration);
 
+builder.Services.AddMvc(options => options.Filters.Add(typeof(FiltroDasExceptions)));
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())

--- a/src/Backend/SistemaDeEstoque.Api/SistemaDeEstoque.Api.csproj
+++ b/src/Backend/SistemaDeEstoque.Api/SistemaDeEstoque.Api.csproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <ProjectReference Include="..\SistemaDeEstoque.Infrastructure\SistemaDeEstoque.Infrastructure.csproj" />
     <ProjectReference Include="..\SistemaDeEstoque.Application\SistemaDeEstoque.Application.csproj" />
+    <ProjectReference Include="..\..\Shared\SistemaDeEstoque.Exceptions\SistemaDeEstoque.Exceptions.csproj" />
+    <ProjectReference Include="..\..\Shared\SistemaDeEstoque.Comunicacao\SistemaDeEstoque.Comunicacao.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Backend/SistemaDeEstoque.Api/Usings.cs
+++ b/src/Backend/SistemaDeEstoque.Api/Usings.cs
@@ -8,6 +8,12 @@ global using SistemaDeEstoque.Application.UseCases.Login.FazerLogin;
 global using SistemaDeEstoque.Application.UseCases.Admin.RecuperarPerfil;
 global using SistemaDeEstoque.Comunicacao.Respostas.Admin;
 
+global using System.Net;
+global using Microsoft.AspNetCore.Mvc.Filters;
+global using SistemaDeEstoque.Comunicacao.Respostas;
+global using SistemaDeEstoque.Exceptions.ErrorMessages;
+global using SistemaDeEstoque.Exceptions.ExceptionsBase;
+global using SistemaDeEstoque.Api.Filtros;
 
 
 

--- a/src/Backend/SistemaDeEstoque.Application/Usings.cs
+++ b/src/Backend/SistemaDeEstoque.Application/Usings.cs
@@ -27,4 +27,3 @@ global using SistemaDeEstoque.Exceptions.ExceptionsBase;
 
 
 
-

--- a/src/Shared/SistemaDeEstoque.Comunicacao/Respostas/RepostaErroJson.cs
+++ b/src/Shared/SistemaDeEstoque.Comunicacao/Respostas/RepostaErroJson.cs
@@ -1,0 +1,19 @@
+namespace SistemaDeEstoque.Comunicacao.Respostas;
+
+public class RespostaErroJson
+{
+    public List<string> Mensagens { get; set; }
+
+    public RespostaErroJson(string mensagem)
+    {
+        Mensagens = new List<string>
+        {
+            mensagem
+        };
+    }
+
+    public RespostaErroJson(List<string> mensagens)
+    {
+        Mensagens = mensagens;
+    }
+}

--- a/src/Shared/SistemaDeEstoque.Exceptions/ErrorMessages/ModelMensagensDeErro.cs
+++ b/src/Shared/SistemaDeEstoque.Exceptions/ErrorMessages/ModelMensagensDeErro.cs
@@ -1,0 +1,6 @@
+namespace SistemaDeEstoque.Exceptions.ErrorMessages;
+
+    public static class ModelMensagensDeErro
+    {
+        public static string ERRO_DESCONHECIDO = "Erro desconhecido.";
+    }

--- a/src/Shared/SistemaDeEstoque.Exceptions/ErrorMessages/UsuarioModelMensagensDeErro.cs
+++ b/src/Shared/SistemaDeEstoque.Exceptions/ErrorMessages/UsuarioModelMensagensDeErro.cs
@@ -1,4 +1,4 @@
-namespace SistemaDeEstoque.Exceptions;
+namespace SistemaDeEstoque.Exceptions.ErrorMessages;
 
 public static class UsuarioModelMensagensDeErro
 {

--- a/src/Shared/SistemaDeEstoque.Exceptions/ExceptionsBase/LoginInvalidoException.cs
+++ b/src/Shared/SistemaDeEstoque.Exceptions/ExceptionsBase/LoginInvalidoException.cs
@@ -1,3 +1,5 @@
+using SistemaDeEstoque.Exceptions.ErrorMessages;
+
 namespace SistemaDeEstoque.Exceptions.ExceptionsBase;
 
     public class LoginInvalidoException : SistemaDeEstoqueException


### PR DESCRIPTION
Adiciona um filtro de exceções que é configurado no MVC services. O filtro captura os erros quando é feito uma requisição nos controllers e ele retorna um objeto com os erros que podem ser: erros de validação, erro de login inválido ou erro desconhecido